### PR TITLE
Made it possible to cache an item forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ An Object containing misc configuration. The following values can be provided:
 If an option Object with a `maxAge` is not provided all items in the cache will by
 default cached for 5 minutes before they expire.
 
+Items can be cached forever by setting `maxAge` to `Infinity`. Items cached forever
+can be overwritten and manually deleted.
+
 Pruning of items from the cache happend when they are touched by one of the methods
 for retrieving items from the cache. By default pruning happens before the method
 returns a value so if an item have expired, `undefined` will be returned for expired
@@ -89,6 +92,8 @@ This method take the following arguments:
  * key - An unique key the value should be stored on in the cache. Required.
  * value - The value to store on the key in the cache. Required.
  * maxAge - Max age before this item should expire. Uses default if not given. Optional.
+
+An item can be cached forever by setting `maxAge` to `Infinity`.
 
 
 ### .get(key)

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -40,7 +40,7 @@ module.exports = class Cache extends stream.Duplex {
             throw new Error('Argument "value" cannot be null or undefined');
         }
 
-        const expires = Date.now() + (maxAge || this.maxAge);
+        const expires = this.constructor._calculateExpire((maxAge || this.maxAge));
         this.store.set(key, { value, expires });
         this.emit('set', { key, value });
         return value;
@@ -112,7 +112,17 @@ module.exports = class Cache extends stream.Duplex {
         // "push" happens on "set" event in constructor
     }
 
+    static _calculateExpire(maxAge = 0) {
+        if (maxAge === Infinity) {
+            return maxAge;
+        }
+        return Date.now() + maxAge;
+    }
+
     static _validate(item = { expires: 0 }, now = Date.now()) {
+        if (item.expires === Infinity) {
+            return false;
+        }
         return (item.expires > now);
     }
 };

--- a/test/cache.js
+++ b/test/cache.js
@@ -542,6 +542,26 @@ tap.test('._write().pipe(_read()) - pipe valid objects through cache - objects s
 
 
 /**
+ * ._calculateExpire()
+ */
+
+tap.test('_calculateExpire() - "maxAge" is Infinity - should return Infinity', (t) => {
+    t.equal(Cache._calculateExpire(Infinity), Infinity);
+    t.end();
+});
+
+tap.test('_calculateExpire() - "maxAge" is a number - should return now timestamp plus the number', (t) => {
+    const clock = lolex.install({ now: 2000 });
+
+    t.equal(Cache._calculateExpire(2000), 4000);
+
+    clock.uninstall();
+    t.end();
+});
+
+
+
+/**
  * ._validate()
  */
 
@@ -550,13 +570,19 @@ tap.test('_validate() - empty argument - should return false', (t) => {
     t.end();
 });
 
-tap.test('_validate() - expires is behind Date.now() - should return false', (t) => {
+tap.test('_validate() - "expires" is Infinity - should return false', (t) => {
+    const expires = Infinity;
+    t.equal(Cache._validate({ expires }), false);
+    t.end();
+});
+
+tap.test('_validate() - "expires" is behind Date.now() - should return false', (t) => {
     const expires = Date.now() - 100000;
     t.equal(Cache._validate({ expires }), false);
     t.end();
 });
 
-tap.test('_validate() - expires is in front of Date.now() - should return true', (t) => {
+tap.test('_validate() - "expires" is in front of Date.now() - should return true', (t) => {
     const expires = Date.now() + 100000;
     t.equal(Cache._validate({ expires }), true);
     t.end();


### PR DESCRIPTION
Items can now be cached forever by setting maxAge to `Infinity`. Items can be deleted, cleared and overwritten.