### PR TITLE
Adding origin to emitted objects on the stream

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,23 +1,110 @@
 'use strict';
 
-const stream = require('readable-stream');
+const stream = require('stream');
+const crypto = require('crypto');
 
-module.exports = class Cache extends stream.Duplex {
-    constructor({ maxAge = 5 * 60 * 1000, stale = false, changefeed = false } = {}) {
+const _set = Symbol('_set');
+const _del = Symbol('_del');
+
+module.exports = class TtlMemCache extends stream.Duplex {
+    constructor({
+        maxAge = 5 * 60 * 1000, stale = false, changefeed = false, id = undefined
+    } = {}) {
         super({
             objectMode: true
         });
-        this.maxAge = maxAge;
-        this.stale = stale;
-        this.changefeed = changefeed;
-        this.store = new Map();
 
-        this.on('set', (obj) => {
+        Object.defineProperty(this, 'maxAge', {
+            value: maxAge,
+        });
+
+        Object.defineProperty(this, 'stale', {
+            value: stale,
+        });
+
+        Object.defineProperty(this, 'changefeed', {
+            value: changefeed,
+        });
+
+        Object.defineProperty(this, 'store', {
+            value: new Map(),
+        });
+
+        Object.defineProperty(this, 'id', {
+            value: id || crypto.randomBytes(3 * 4).toString('base64'),
+        });
+
+        this.on('broadcast', (obj, options) => {
             if (this._readableState.flowing) {
-                this.push(obj);
+                if (options.origin === undefined) {
+                    options.origin = this.id;
+                }
+
+                this.push({
+                    key: obj.key,
+                    value: obj.value,
+                    origin: options.origin
+                });
             }
         });
     }
+
+    /**
+     * Meta
+     */
+
+    get [Symbol.toStringTag]() {
+        return 'TtlMemCache';
+    }
+
+    /**
+     * Private methods
+     */
+
+    [_set](key, value, options = {}) {
+        if (key === null || key === undefined) {
+            throw new Error('Argument "key" cannot be null or undefined');
+        }
+        if (value === null || value === undefined) {
+            throw new Error('Argument "value" cannot be null or undefined');
+        }
+
+        const expires = this.constructor._calculateExpire((options.maxAge || this.maxAge));
+
+        const eventObj = {
+            key,
+            value
+        };
+
+        if (this.changefeed) {
+            eventObj.value = {
+                oldVal: this.get(key),
+                newVal: value
+            };
+        }
+
+        this.store.set(key, { value, expires });
+        this.emit('broadcast', eventObj, options);
+        this.emit('set', eventObj);
+        return value;
+    }
+
+    [_del](key, options = {}) {
+        const item = this.store.get(key);
+        const success = this.store.delete(key);
+        if (item) {
+            this.emit('broadcast', {
+                key,
+                value: null
+            }, options);
+            this.emit('dispose', key, item.value);
+        }
+        return success;
+    }
+
+    /**
+     * Public methods
+     */
 
     get(key) {
         const item = this.store.get(key);
@@ -36,39 +123,13 @@ module.exports = class Cache extends stream.Duplex {
     }
 
     set(key, value, maxAge) {
-        if (key === null || key === undefined) {
-            throw new Error('Argument "key" cannot be null or undefined');
-        }
-        if (value === null || value === undefined) {
-            throw new Error('Argument "value" cannot be null or undefined');
-        }
-
-        const expires = this.constructor._calculateExpire((maxAge || this.maxAge));
-
-        const eventObj = {
-            key,
-            value
-        };
-
-        if (this.changefeed) {
-            eventObj.value = {
-                oldVal: this.get(key),
-                newVal: value
-            };
-        }
-
-        this.store.set(key, { value, expires });
-        this.emit('set', eventObj);
-        return value;
+        return this[_set](key, value, {
+            maxAge
+        });
     }
 
     del(key) {
-        const item = this.store.get(key);
-        const success = this.store.delete(key);
-        if (item) {
-            this.emit('dispose', key, item.value);
-        }
-        return success;
+        return this[_del](key);
     }
 
     entries(mutator) {
@@ -133,14 +194,26 @@ module.exports = class Cache extends stream.Duplex {
         return this.store.size;
     }
 
+    /**
+     * Stream methods
+     */
+
     _write(obj, enc, next) {
+        const options = {
+            origin: obj.origin ? obj.origin : this.id
+        };
+
+        if (obj.origin === this.id) {
+            return next();
+        }
+
         if (obj.key && obj.value) {
-            this.set(obj.key, obj.value);
+            this[_set](obj.key, obj.value, options);
             return next();
         }
 
         if (obj.key && (obj.value === null || obj.value === undefined)) {
-            this.del(obj.key);
+            this[_del](obj.key, options);
             return next();
         }
 
@@ -151,6 +224,10 @@ module.exports = class Cache extends stream.Duplex {
     _read() {
         // "push" happens on "set" event in constructor
     }
+
+    /**
+     * Static methods
+     */
 
     static _calculateExpire(maxAge = 0) {
         if (maxAge === Infinity) {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,5 @@
     "benchmark": "2.1.4",
     "lolex": "2.3.0",
     "tap": "10.7.3"
-  },
-  "dependencies": {
-    "readable-stream": "2.3.3"
   }
 }


### PR DESCRIPTION
This PR ads a origin to the objects emitted on the stream. It also breaks broadcasting of incomming objects when an incomming object has the same origin as the id of the instance of the cache. This makes it possible to pipe caches together in a circle and distribute objects between all instances in the circle.