### PR TITLE
Introduce a structured entry object

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -10,14 +10,14 @@ const _del = Symbol('_del');
 
 const TtlMemCache = class TtlMemCache extends stream.Duplex {
     constructor({
-        maxAge = 5 * 60 * 1000, stale = false, changefeed = false, id = undefined
+        ttl = 5 * 60 * 1000, stale = false, changefeed = false, id = undefined
     } = {}) {
         super({
             objectMode: true
         });
 
-        Object.defineProperty(this, 'maxAge', {
-            value: maxAge,
+        Object.defineProperty(this, 'ttl', {
+            value: ttl,
             enumerable: true,
         });
 
@@ -60,7 +60,7 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
      */
 
     [_set]({
-        key, value, ttl = this.maxAge, origin = this.id, expires
+        key, value, ttl = this.ttl, origin = this.id, expires
     }) {
         if (utils.isEmpty(key)) {
             throw new Error('Argument "key" cannot be null or undefined');

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,6 +2,7 @@
 
 const stream = require('stream');
 const crypto = require('crypto');
+const utils = require('./utils');
 const Entry = require('./entry');
 
 const _set = Symbol('_set');
@@ -61,10 +62,10 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
     [_set]({
         key, value, ttl = this.maxAge, origin = this.id, expires
     }) {
-        if (key === null || key === undefined) {
+        if (utils.isEmpty(key)) {
             throw new Error('Argument "key" cannot be null or undefined');
         }
-        if (value === null || value === undefined) {
+        if (utils.isEmpty(value)) {
             throw new Error('Argument "value" cannot be null or undefined');
         }
 
@@ -91,7 +92,7 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
     [_del]({ key }) {
         const item = this.store.get(key);
         const success = this.store.delete(key);
-        if (item) {
+        if (utils.isNotEmpty(item)) {
             this.emit('broadcast', new Entry({ key }));
             this.emit('dispose', key, item.value);
         }
@@ -104,7 +105,7 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
 
     get(key) {
         const item = this.store.get(key);
-        if (item) {
+        if (utils.isNotEmpty(item)) {
             const expired = item.expired();
 
             if (expired) {
@@ -133,7 +134,7 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
     }
 
     entries(mutator) {
-        const mutate = (typeof mutator === 'function');
+        const mutate = utils.isFunction(mutator);
         const now = Date.now();
         const arr = [];
 
@@ -180,7 +181,7 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
             throw new Error('Argument "items" is not an Array');
         }
         return items.map((item) => {
-            if (item[0] && item[1] && item[1].value && item[1].expires) {
+            if (Entry.assertStrict(item[1])) {
                 const entry = new Entry(item[1]);
                 this.store.set(entry.key, entry);
                 return entry.key;
@@ -198,16 +199,16 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
      */
 
     _write(obj, enc, next) {
-        if (obj.origin && (obj.origin === this.id)) {
+        if (utils.isNotEmpty(obj.origin) && (obj.origin === this.id)) {
             return next();
         }
 
-        if (obj.key && obj.value) {
+        if (Entry.assertLoose(obj)) {
             this[_set](obj);
             return next();
         }
 
-        if (obj.key && (obj.value === null || obj.value === undefined)) {
+        if (utils.isNotEmpty(obj.key) && utils.isEmpty(obj.value)) {
             this[_del](obj);
             return next();
         }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,7 +2,7 @@
 
 const stream = require('stream');
 const crypto = require('crypto');
-const utils = require('./utils');
+const Entry = require('./entry');
 
 const _set = Symbol('_set');
 const _del = Symbol('_del');
@@ -39,14 +39,9 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
             enumerable: true,
         });
 
-        this.on('broadcast', (obj, options) => {
+        this.on('broadcast', (entry) => {
             if (this._readableState.flowing) {
-                const origin = options.origin ? options.origin : this.id;
-                this.push({
-                    key: obj.key,
-                    value: obj.value,
-                    origin,
-                });
+                this.push(entry);
             }
         });
     }
@@ -63,7 +58,7 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
      * Private methods
      */
 
-    [_set](key, value, options = {}) {
+    [_set](key, value, ttl = this.maxAge, origin = this.id, expires) {
         if (key === null || key === undefined) {
             throw new Error('Argument "key" cannot be null or undefined');
         }
@@ -71,34 +66,31 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
             throw new Error('Argument "value" cannot be null or undefined');
         }
 
-        const expires = utils.calculateExpire((options.maxAge || this.maxAge));
-
-        const eventObj = {
-            key,
-            value
-        };
-
+        let item = value;
         if (this.changefeed) {
-            eventObj.value = {
+            item = {
                 oldVal: this.get(key),
                 newVal: value
             };
         }
 
-        this.store.set(key, { value, expires });
-        this.emit('broadcast', eventObj, options);
-        this.emit('set', eventObj);
+        const entry = new Entry({
+            key, value, ttl, origin, expires
+        });
+
+        this.store.set(key, entry);
+
+        this.emit('broadcast', entry);
+        this.emit('set', key, item);
+
         return value;
     }
 
-    [_del](key, options = {}) {
+    [_del](key) {
         const item = this.store.get(key);
         const success = this.store.delete(key);
         if (item) {
-            this.emit('broadcast', {
-                key,
-                value: null
-            }, options);
+            this.emit('broadcast', new Entry({ key }));
             this.emit('dispose', key, item.value);
         }
         return success;
@@ -111,23 +103,27 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
     get(key) {
         const item = this.store.get(key);
         if (item) {
-            if (utils.validate(item)) {
+            const expired = item.expired();
+
+            if (expired) {
+                this.del(key);
+            }
+
+            if (expired && this.stale) {
                 return item.value;
             }
 
-            this.del(key);
-
-            if (this.stale) {
-                return item.value;
+            if (expired) {
+                return null;
             }
+
+            return item.value;
         }
         return null;
     }
 
-    set(key, value, maxAge) {
-        return this[_set](key, value, {
-            maxAge
-        });
+    set(key, value, ttl) {
+        return this[_set](key, value, ttl);
     }
 
     del(key) {
@@ -140,13 +136,7 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
         const arr = [];
 
         this.store.forEach((item, key) => {
-            if (utils.validate(item, now)) {
-                if (mutate) {
-                    arr.push(mutator(item.value));
-                } else {
-                    arr.push(item.value);
-                }
-            } else {
+            if (item.expired(now)) {
                 if (this.stale) {
                     if (mutate) {
                         arr.push(mutator(item.value));
@@ -155,6 +145,10 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
                     }
                 }
                 this.del(key);
+            } else if (mutate) {
+                arr.push(mutator(item.value));
+            } else {
+                arr.push(item.value);
             }
         });
 
@@ -164,7 +158,7 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
     prune() {
         const now = Date.now();
         this.store.forEach((item, key) => {
-            if (!utils.validate(item, now)) {
+            if (item.expired(now)) {
                 this.del(key);
             }
         });
@@ -185,8 +179,9 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
         }
         return items.map((item) => {
             if (item[0] && item[1] && item[1].value && item[1].expires) {
-                this.store.set(item[0], item[1]);
-                return item[0];
+                const entry = new Entry(item[1]);
+                this.store.set(entry.key, entry);
+                return entry.key;
             }
             return undefined;
         }).filter(item => item);
@@ -201,21 +196,17 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
      */
 
     _write(obj, enc, next) {
-        const options = {
-            origin: obj.origin ? obj.origin : this.id
-        };
-
-        if (obj.origin === this.id) {
+        if (obj.origin && (obj.origin === this.id)) {
             return next();
         }
 
         if (obj.key && obj.value) {
-            this[_set](obj.key, obj.value, options);
+            this[_set](obj.key, obj.value, obj.ttl, obj.origin, obj.expires);
             return next();
         }
 
         if (obj.key && (obj.value === null || obj.value === undefined)) {
-            this[_del](obj.key, options);
+            this[_del](obj.key);
             return next();
         }
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -58,7 +58,9 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
      * Private methods
      */
 
-    [_set](key, value, ttl = this.maxAge, origin = this.id, expires) {
+    [_set]({
+        key, value, ttl = this.maxAge, origin = this.id, expires
+    }) {
         if (key === null || key === undefined) {
             throw new Error('Argument "key" cannot be null or undefined');
         }
@@ -86,7 +88,7 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
         return value;
     }
 
-    [_del](key) {
+    [_del]({ key }) {
         const item = this.store.get(key);
         const success = this.store.delete(key);
         if (item) {
@@ -123,11 +125,11 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
     }
 
     set(key, value, ttl) {
-        return this[_set](key, value, ttl);
+        return this[_set]({ key, value, ttl });
     }
 
     del(key) {
-        return this[_del](key);
+        return this[_del]({ key });
     }
 
     entries(mutator) {
@@ -201,12 +203,12 @@ const TtlMemCache = class TtlMemCache extends stream.Duplex {
         }
 
         if (obj.key && obj.value) {
-            this[_set](obj.key, obj.value, obj.ttl, obj.origin, obj.expires);
+            this[_set](obj);
             return next();
         }
 
         if (obj.key && (obj.value === null || obj.value === undefined)) {
-            this[_del](obj.key);
+            this[_del](obj);
             return next();
         }
 

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const utils = require('./utils');
+
+const _key = Symbol('_key');
+const _value = Symbol('_value');
+const _ttl = Symbol('_ttl');
+const _origin = Symbol('_origin');
+const _expires = Symbol('_expires');
+
+const TtlMemCacheEntry = class TtlMemCacheEntry {
+    constructor({
+        key, value = null, ttl = -1, origin = null, expires
+    } = {}) {
+        this[_key] = key;
+        this[_value] = value;
+        this[_ttl] = ttl;
+        this[_origin] = origin;
+        this[_expires] = expires || utils.calculateExpire(this.ttl);
+    }
+
+    /**
+     * Meta
+     */
+
+    get [Symbol.toStringTag]() {
+        return 'TtlMemCacheEntry';
+    }
+
+    /**
+     * Public keys
+     */
+
+    get key() {
+        return this[_key];
+    }
+
+    set key(val) {
+        throw new Error('Cannot set read-only property.');
+    }
+
+    get value() {
+        return this[_value];
+    }
+
+    set value(val) {
+        throw new Error('Cannot set read-only property.');
+    }
+
+    get ttl() {
+        return this[_ttl];
+    }
+
+    set ttl(val) {
+        throw new Error('Cannot set read-only property.');
+    }
+
+    get origin() {
+        return this[_origin];
+    }
+
+    set origin(val) {
+        throw new Error('Cannot set read-only property.');
+    }
+
+    get expires() {
+        return this[_expires];
+    }
+
+    set expires(val) {
+        throw new Error('Cannot set read-only property.');
+    }
+
+    /**
+     * Public methods
+     */
+
+    expired(now) {
+        return utils.expired(this.expires, now);
+    }
+
+    toJSON() {
+        return {
+            key: this.key,
+            value: this.value,
+            ttl: this.ttl,
+            origin: this.origin,
+            expires: this.expires,
+            type: 'TtlMemCacheEntry',
+        };
+    }
+};
+
+module.exports = TtlMemCacheEntry;

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -89,6 +89,20 @@ const TtlMemCacheEntry = class TtlMemCacheEntry {
             type: 'TtlMemCacheEntry',
         };
     }
+
+    static assertLoose(obj = {}) {
+        if (utils.isNotEmpty(obj.key) && utils.isNotEmpty(obj.value)) {
+            return true;
+        }
+        return false;
+    }
+
+    static assertStrict(obj = {}) {
+        if (utils.isNotEmpty(obj.key) && utils.isNotEmpty(obj.value) && utils.isNotEmpty(obj.ttl)) {
+            return true;
+        }
+        return false;
+    }
 };
 
 module.exports = TtlMemCacheEntry;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,3 +13,15 @@ module.exports.expired = (expires = 0, now = Date.now()) => {
     }
     return expires < now;
 };
+
+module.exports.isEmpty = (value) => {
+    return (value === null || value === undefined);
+};
+
+module.exports.isNotEmpty = (value) => {
+    return !this.isEmpty(value);
+};
+
+module.exports.isFunction = (value) => {
+    return ({}.toString.call(value) === '[object Function]');
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,15 +1,15 @@
 'use strict';
 
-module.exports.calculateExpire = (maxAge = 0) => {
-    if (maxAge === Infinity) {
-        return maxAge;
+module.exports.calculateExpire = (ttl = 0) => {
+    if (ttl === Infinity) {
+        return ttl;
     }
-    return Date.now() + maxAge;
+    return Date.now() + ttl;
 };
 
-module.exports.validate = (item = { expires: 0 }, now = Date.now()) => {
-    if (item.expires === Infinity) {
+module.exports.expired = (expires = 0, now = Date.now()) => {
+    if (expires === Infinity) {
         return false;
     }
-    return (item.expires > now);
+    return expires < now;
 };

--- a/test/cache.js
+++ b/test/cache.js
@@ -47,16 +47,16 @@ tap.test('cache() - object type - should be TtlMemCache', (t) => {
     t.end();
 });
 
-tap.test('cache() - without maxAge - should set default maxAge', (t) => {
+tap.test('cache() - without ttl - should set default ttl', (t) => {
     const cache = new Cache();
-    t.equal(cache.maxAge, (5 * 60 * 1000));
+    t.equal(cache.ttl, (5 * 60 * 1000));
     t.end();
 });
 
-tap.test('cache() - with maxAge - should set default maxAge', (t) => {
-    const maxAge = (60 * 60 * 1000);
-    const cache = new Cache({ maxAge });
-    t.equal(cache.maxAge, maxAge);
+tap.test('cache() - with ttl - should set default ttl', (t) => {
+    const ttl = (60 * 60 * 1000);
+    const cache = new Cache({ ttl });
+    t.equal(cache.ttl, ttl);
     t.end();
 });
 
@@ -109,13 +109,13 @@ tap.test('cache.set() - with key and value - should set value on key in storage'
     t.end();
 });
 
-tap.test('cache.set() - without ttl - should set default maxAge', (t) => {
+tap.test('cache.set() - without ttl - should set default ttl', (t) => {
     const clock = lolex.install();
     clock.tick(100000);
 
     const cache = new Cache();
     cache.set('foo', 'bar');
-    t.equal(cache.store.get('foo').expires, 400000); // default maxAge + lolex tick time
+    t.equal(cache.store.get('foo').expires, 400000); // default ttl + lolex tick time
 
     clock.uninstall();
     t.end();
@@ -176,7 +176,7 @@ tap.test('cache.set() - "changefeed : true" and key does not have a value - "on.
 
 tap.test('cache.set() - "changefeed : true" and item has expired - "on.set" event should emit new value and "null" for old value', (t) => {
     const clock = lolex.install();
-    const cache = new Cache({ maxAge: 2 * 1000, changefeed: true });
+    const cache = new Cache({ ttl: 2 * 1000, changefeed: true });
     cache.set('foo', 'bar');
 
     cache.on('set', (key, value) => {
@@ -194,7 +194,7 @@ tap.test('cache.set() - "changefeed : true" and item has expired - "on.set" even
 
 tap.test('cache.set() - "changefeed : true, stale : true" and item has expired - "on.set" event should emit old and new value', (t) => {
     const clock = lolex.install();
-    const cache = new Cache({ maxAge: 2 * 1000, stale: true, changefeed: true });
+    const cache = new Cache({ ttl: 2 * 1000, stale: true, changefeed: true });
     cache.set('foo', 'bar');
 
     cache.on('set', (key, value) => {
@@ -224,7 +224,7 @@ tap.test('cache.get() - get set value - should return set value', (t) => {
 
 tap.test('cache.get() - get value until timeout - should return value until timeout', (t) => {
     const clock = lolex.install();
-    const cache = new Cache({ maxAge: 2 * 1000 });
+    const cache = new Cache({ ttl: 2 * 1000 });
 
     const key = 'foo';
     const value = 'bar';
@@ -245,7 +245,7 @@ tap.test('cache.get() - get value until timeout - should return value until time
 tap.test('cache.get() - get value until timeout - should emit dispose event on timeout', (t) => {
     const clock = lolex.install();
 
-    const cache = new Cache({ maxAge: 2 * 1000 });
+    const cache = new Cache({ ttl: 2 * 1000 });
     cache.on('dispose', (key) => {
         t.equal(key, 'foo');
         t.end();
@@ -261,7 +261,7 @@ tap.test('cache.get() - get value until timeout - should emit dispose event on t
 
 tap.test('cache.get() - cache set to return stale items - should return item once after timeout', (t) => {
     const clock = lolex.install();
-    const cache = new Cache({ maxAge: 2 * 1000, stale: true });
+    const cache = new Cache({ ttl: 2 * 1000, stale: true });
 
     const key = 'foo';
     const value = 'bar';

--- a/test/cache.js
+++ b/test/cache.js
@@ -699,13 +699,13 @@ tap.test('cache.load() - one entry is missing "values.value" - should set valid 
     t.end();
 });
 
-tap.test('cache.load() - one entry is missing "values.expires" - should set valid entries in cache', (t) => {
+tap.test('cache.load() - one entry is missing "values.ttl" - should set valid entries in cache', (t) => {
     const dump = [
         ['a', {
             key: 'a', value: 'bar', ttl: 2000, origin: 'org', expires: 2000
         }],
         ['b', {
-            key: 'b', value: 'bar', ttl: 2000, origin: 'org'
+            key: 'b', value: 'bar', origin: 'org'
         }],
         ['c', {
             key: 'c', value: 'xyz', ttl: 2000, origin: 'org', expires: 2000

--- a/test/entry.js
+++ b/test/entry.js
@@ -1,0 +1,275 @@
+'use strict';
+
+const Entry = require('../lib/entry');
+const lolex = require('lolex');
+const tap = require('tap');
+
+/**
+ * Constructor
+ */
+
+tap.test('entry() - object type - should be TtlMemCacheEntry', (t) => {
+    const entry = new Entry();
+    t.equal(Object.prototype.toString.call(entry), '[object TtlMemCacheEntry]');
+    t.end();
+});
+
+tap.test('entry() - no values - should set defaults', (t) => {
+    const clock = lolex.install();
+    clock.tick(1000);
+
+    const entry = new Entry();
+    t.type(entry.key, 'undefined');
+    t.type(entry.value, 'null');
+    t.type(entry.origin, 'null');
+
+    t.equal(entry.ttl, -1);
+    t.equal(entry.expires, 999);
+
+    clock.uninstall();
+    t.end();
+});
+
+tap.test('entry() - define all values - should set all values', (t) => {
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 1000,
+        origin: 'source',
+        expires: 3000,
+    });
+    t.equal(entry.key, 'a');
+    t.equal(entry.value, 'foo');
+    t.equal(entry.origin, 'source');
+
+    t.equal(entry.ttl, 1000);
+    t.equal(entry.expires, 3000);
+
+    t.end();
+});
+
+tap.test('entry() - define all values except expires - should set all values and calculate expires', (t) => {
+    const clock = lolex.install();
+    clock.tick(1000);
+
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 1000,
+        origin: 'source',
+    });
+    t.equal(entry.key, 'a');
+    t.equal(entry.value, 'foo');
+    t.equal(entry.origin, 'source');
+
+    t.equal(entry.ttl, 1000);
+    t.equal(entry.expires, 2000);
+
+    clock.uninstall();
+    t.end();
+});
+
+/**
+ * Setters
+ */
+
+tap.test('entry.key - set value on "key" property - should throw', (t) => {
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 1000,
+        origin: 'source',
+    });
+    t.throws(() => {
+        entry.key = 'b';
+    }, new Error('Cannot set read-only property.'));
+    t.end();
+});
+
+tap.test('entry.value - set value on "value" property - should throw', (t) => {
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 1000,
+        origin: 'source',
+    });
+    t.throws(() => {
+        entry.value = 'bar';
+    }, new Error('Cannot set read-only property.'));
+    t.end();
+});
+
+tap.test('entry.ttl - set value on "ttl" property - should throw', (t) => {
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 1000,
+        origin: 'source',
+    });
+    t.throws(() => {
+        entry.ttl = 2000;
+    }, new Error('Cannot set read-only property.'));
+    t.end();
+});
+
+tap.test('entry.origin - set value on "origin" property - should throw', (t) => {
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 1000,
+        origin: 'source',
+    });
+    t.throws(() => {
+        entry.origin = 'src';
+    }, new Error('Cannot set read-only property.'));
+    t.end();
+});
+
+tap.test('entry.expires - set value on "expires" property - should throw', (t) => {
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 1000,
+        origin: 'source',
+    });
+    t.throws(() => {
+        entry.expires = 2000;
+    }, new Error('Cannot set read-only property.'));
+    t.end();
+});
+
+/**
+ * .expired()
+ */
+
+tap.test('.expired() - expire time is in front of now - should return "false"', (t) => {
+    const clock = lolex.install();
+
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    });
+
+    clock.tick(1000);
+
+    t.false(entry.expired());
+
+    clock.uninstall();
+    t.end();
+});
+
+tap.test('.expired() - expire time is behind of now - should return "true"', (t) => {
+    const clock = lolex.install();
+
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    });
+
+    clock.tick(4000);
+
+    t.true(entry.expired());
+
+    clock.uninstall();
+    t.end();
+});
+
+tap.test('.expired() - "now" argument is provided - expire time is in front of now - should return "false"', (t) => {
+    const clock = lolex.install();
+
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    });
+
+    clock.tick(4000);
+
+    t.false(entry.expired(1000));
+
+    clock.uninstall();
+    t.end();
+});
+
+tap.test('.expired() - "now" argument is provided - expire time is behind of now - should return "true"', (t) => {
+    const clock = lolex.install();
+
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    });
+
+    clock.tick(1000);
+
+    t.true(entry.expired(4000));
+
+    clock.uninstall();
+    t.end();
+});
+
+/**
+ * .toJSON()
+ */
+
+tap.test('.toJSON() - call method - should return an object literal of the Entry object', (t) => {
+    const clock = lolex.install();
+    clock.tick(1000);
+
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    });
+
+    const result = entry.toJSON();
+
+    t.type(result, 'object');
+    t.equal(result.key, 'a');
+    t.equal(result.value, 'foo');
+    t.equal(result.ttl, 2000);
+    t.equal(result.origin, 'source');
+    t.equal(result.expires, 3000);
+
+    clock.uninstall();
+    t.end();
+});
+
+tap.test('.toJSON() - call method - should append a "type" property with "TtlMemCacheEntry" as value', (t) => {
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    });
+
+    const result = entry.toJSON();
+
+    t.equal(result.type, 'TtlMemCacheEntry');
+    t.end();
+});
+
+tap.test('.toJSON() - call JSON.stringify on Entry object - should return a String representation of the Entry object', (t) => {
+    const clock = lolex.install();
+    clock.tick(1000);
+
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    });
+
+    const result = JSON.stringify(entry);
+    t.equal(result, '{"key":"a","value":"foo","ttl":2000,"origin":"source","expires":3000,"type":"TtlMemCacheEntry"}');
+
+    clock.uninstall();
+    t.end();
+});

--- a/test/entry.js
+++ b/test/entry.js
@@ -273,3 +273,120 @@ tap.test('.toJSON() - call JSON.stringify on Entry object - should return a Stri
     clock.uninstall();
     t.end();
 });
+
+/**
+ * .assertLoose()
+ */
+
+tap.test('.assertLoose() - Entry object - should return true', (t) => {
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    });
+    t.true(Entry.assertLoose(entry));
+    t.end();
+});
+
+tap.test('.assertLoose() - Object literal with "key" and "value" - should return true', (t) => {
+    const entry = {
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    };
+    t.true(Entry.assertLoose(entry));
+    t.end();
+});
+
+tap.test('.assertLoose() - Object literal without "key" - should return false', (t) => {
+    const entry = {
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    };
+    t.false(Entry.assertLoose(entry));
+    t.end();
+});
+
+tap.test('.assertLoose() - Object literal without "value" - should return false', (t) => {
+    const entry = {
+        key: 'a',
+        ttl: 2000,
+        origin: 'source',
+    };
+    t.false(Entry.assertLoose(entry));
+    t.end();
+});
+
+tap.test('.assertLoose() - Object literal without "key" and "value" - should return false', (t) => {
+    t.false(Entry.assertLoose({}));
+    t.end();
+});
+
+tap.test('.assertLoose() - No argument - should return false', (t) => {
+    t.false(Entry.assertLoose());
+    t.end();
+});
+
+/**
+ * .assertStrict()
+ */
+
+tap.test('.assertStrict() - x - should return true', (t) => {
+    const entry = new Entry({
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    });
+    t.true(Entry.assertStrict(entry));
+    t.end();
+});
+
+tap.test('.assertStrict() - Object literal with "key", "value" and "ttl" - should return true', (t) => {
+    const entry = {
+        key: 'a',
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    };
+    t.true(Entry.assertStrict(entry));
+    t.end();
+});
+
+tap.test('.assertStrict() - Object literal without "key" - should return false', (t) => {
+    const entry = {
+        value: 'foo',
+        ttl: 2000,
+        origin: 'source',
+    };
+    t.false(Entry.assertStrict(entry));
+    t.end();
+});
+
+tap.test('.assertStrict() - Object literal without "value" - should return false', (t) => {
+    const entry = {
+        key: 'a',
+        ttl: 2000,
+        origin: 'source',
+    };
+    t.false(Entry.assertStrict(entry));
+    t.end();
+});
+
+tap.test('.assertStrict() - Object literal without "ttl" - should return false', (t) => {
+    const entry = {
+        key: 'a',
+        value: 'foo',
+        origin: 'source',
+    };
+    t.false(Entry.assertStrict(entry));
+    t.end();
+});
+
+tap.test('.assertStrict() - No argument - should return false', (t) => {
+    t.false(Entry.assertStrict());
+    t.end();
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -33,28 +33,28 @@ tap.test('utils.calculateExpire() - empty argument - should return now timestamp
 
 
 /**
- * .validate()
+ * .expired()
  */
 
-tap.test('utils.validate() - empty argument - should return false', (t) => {
-    t.equal(utils.validate(), false);
+tap.test('utils.expired() - empty argument - should return true', (t) => {
+    t.equal(utils.expired(), true);
     t.end();
 });
 
-tap.test('utils.validate() - "expires" is Infinity - should return false', (t) => {
+tap.test('utils.expired() - "expires" is Infinity - should return false', (t) => {
     const expires = Infinity;
-    t.equal(utils.validate({ expires }), false);
+    t.equal(utils.expired(expires), false);
     t.end();
 });
 
-tap.test('utils.validate() - "expires" is behind Date.now() - should return false', (t) => {
+tap.test('utils.expired() - "expires" is behind Date.now() - should return true', (t) => {
     const expires = Date.now() - 100000;
-    t.equal(utils.validate({ expires }), false);
+    t.equal(utils.expired(expires), true);
     t.end();
 });
 
-tap.test('utils.validate() - "expires" is in front of Date.now() - should return true', (t) => {
+tap.test('utils.expired() - "expires" is in front of Date.now() - should return false', (t) => {
     const expires = Date.now() + 100000;
-    t.equal(utils.validate({ expires }), true);
+    t.equal(utils.expired(expires), false);
     t.end();
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -31,30 +31,92 @@ tap.test('utils.calculateExpire() - empty argument - should return now timestamp
     t.end();
 });
 
-
 /**
  * .expired()
  */
 
 tap.test('utils.expired() - empty argument - should return true', (t) => {
-    t.equal(utils.expired(), true);
+    t.true(utils.expired());
     t.end();
 });
 
 tap.test('utils.expired() - "expires" is Infinity - should return false', (t) => {
     const expires = Infinity;
-    t.equal(utils.expired(expires), false);
+    t.false(utils.expired(expires));
     t.end();
 });
 
 tap.test('utils.expired() - "expires" is behind Date.now() - should return true', (t) => {
     const expires = Date.now() - 100000;
-    t.equal(utils.expired(expires), true);
+    t.true(utils.expired(expires));
     t.end();
 });
 
 tap.test('utils.expired() - "expires" is in front of Date.now() - should return false', (t) => {
     const expires = Date.now() + 100000;
-    t.equal(utils.expired(expires), false);
+    t.false(utils.expired(expires));
+    t.end();
+});
+
+/**
+ * .isEmpty()
+ */
+
+tap.test('utils.isEmpty() - value is not empty - should return false', (t) => {
+    t.false(utils.isEmpty('foo'));
+    t.false(utils.isEmpty(1));
+    t.false(utils.isEmpty({}));
+    t.false(utils.isEmpty([1]));
+    t.end();
+});
+
+tap.test('utils.isEmpty() - value is "null" - should return true', (t) => {
+    t.true(utils.isEmpty(null));
+    t.end();
+});
+
+tap.test('utils.isEmpty() - value is "undefined" - should return true', (t) => {
+    t.true(utils.isEmpty(undefined));
+    t.end();
+});
+
+/**
+ * .isNotEmpty()
+ */
+
+tap.test('utils.isNotEmpty() - value is not empty - should return true', (t) => {
+    t.true(utils.isNotEmpty('foo'));
+    t.true(utils.isNotEmpty(1));
+    t.true(utils.isNotEmpty({}));
+    t.true(utils.isNotEmpty([1]));
+    t.end();
+});
+
+tap.test('utils.isNotEmpty() - value is "null" - should return false', (t) => {
+    t.false(utils.isNotEmpty(null));
+    t.end();
+});
+
+tap.test('utils.isNotEmpty() - value is "undefined" - should return false', (t) => {
+    t.false(utils.isNotEmpty(undefined));
+    t.end();
+});
+
+/**
+ * .isFunction()
+ */
+
+tap.test('utils.isFunction() - value is not a function - should return false', (t) => {
+    t.false(utils.isFunction());
+    t.false(utils.isFunction('foo'));
+    t.false(utils.isFunction(1));
+    t.false(utils.isFunction({}));
+    t.false(utils.isFunction([1]));
+    t.end();
+});
+
+tap.test('utils.isFunction() - value is a function - should return true', (t) => {
+    t.true(utils.isFunction(function() {}));
+    t.true(utils.isFunction(() => {}));
     t.end();
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -116,7 +116,13 @@ tap.test('utils.isFunction() - value is not a function - should return false', (
 });
 
 tap.test('utils.isFunction() - value is a function - should return true', (t) => {
-    t.true(utils.isFunction(function() {}));
-    t.true(utils.isFunction(() => {}));
+    const fn = function fn(x) {
+        return x;
+    };
+    const arr = (x) => {
+        return x;
+    };
+    t.true(utils.isFunction(fn));
+    t.true(utils.isFunction(arr));
     t.end();
 });


### PR DESCRIPTION
This introduces an structured entry object which holds the item to be cached in the cache. This entry object  is also used on the stream to exchange cache items between cache instances.

Its also introduced several optimizations on different validation checks in the cache.

There are a couple of breaking changes:

 * `maxAge` is now renamed to `ttl` on the global constructor.
 * The stream does not emit a changelog value if `changelog` is set to `true`.
 * The `set` event does now emit `key` and `item` instead of a object with these two values. This does now align with the `dispose` event.